### PR TITLE
docs: new maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,2 @@
 Lars Holm Nielsen <lars.holm.nielsen@cern.ch> (@lnielsen)
+Alexander Ioannidis <a.ioannidis@cern.ch> (@slint)


### PR DESCRIPTION
Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>